### PR TITLE
Slime Block Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <plib.version>1.4-SNAPSHOT</plib.version>
-    <bukkit.version>1.9-SNAPSHOT</bukkit.version>
+    <bukkit.version>1.9.4-R0.1-SNAPSHOT</bukkit.version>
   </properties>
   
   <scm>

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/FeatureBlockItemSpawn.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/FeatureBlockItemSpawn.java
@@ -74,11 +74,11 @@ public class FeatureBlockItemSpawn extends CoreModule<LimitedCreative> implement
     }
     
     public void block(Block block, Player player) {
-        if (player.getItemInHand().containsEnchantment(Enchantment.SILK_TOUCH)) {
+        if (player.getInventory().getItemInMainHand().containsEnchantment(Enchantment.SILK_TOUCH)) {
             block(block.getLocation(), block.getType());
         } else {
             // doesn't include silktouch
-            for (ItemStack i : block.getDrops(player.getItemInHand())) {
+            for (ItemStack i : block.getDrops(player.getInventory().getItemInMainHand())) {
                 block(block.getLocation(), i.getType());
             }
         }

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/BlockListener.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/BlockListener.java
@@ -1,6 +1,5 @@
 package de.jaschastarke.minecraft.limitedcreative.blockstate;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -144,19 +143,15 @@ public class BlockListener implements Listener {
             return;
         event.getBlock().setMetadata("LCBS_pistonIsAlreadyExtended", blockAlreadExtended);
         
-        Block source = event.getBlock().getRelative(event.getDirection());
         /*if (mod.isDebug())
             mod.getLog().debug("PistonExtend "+source.getType()+" "+source.getLocation()+" "+event.getDirection());*/
         
-        List<Block> movedBlocks = new ArrayList<Block>();
-        while (source != null && source.getType() != Material.AIR) {
-            movedBlocks.add(0, source); // put on top, so iterating the
-            source = source.getRelative(event.getDirection());
-        }
+        List<Block> movedBlocks = event.getBlocks();
         
         if (movedBlocks.size() > 0) {
             DBTransaction update = mod.getModel().groupUpdate();
-            for (Block sblock : movedBlocks) {
+            for(int count = movedBlocks.size()-1; count >= 0; count--){
+        	Block sblock = movedBlocks.get(count);
                 Block dest = sblock.getRelative(event.getDirection());
                 if (mod.isDebug())
                     mod.getLog().debug("PistionExtend moves "+sblock.getType()+"-Block from "+sblock.getLocation()+" to "+dest.getLocation());
@@ -173,12 +168,19 @@ public class BlockListener implements Listener {
             return;
         event.getBlock().removeMetadata("LCBS_pistonIsAlreadyExtended", mod.getPlugin());
         
-        Block dest = event.getBlock().getRelative(event.getDirection());
-        Block source = dest.getRelative(event.getDirection());
-        if (event.isSticky() && source.getType() != Material.AIR) {
-            if (mod.isDebug())
-                mod.getLog().debug("PistionRetract moves "+source.getType()+"-Block from "+source.getLocation()+" to "+dest.getLocation());
-            mod.getModel().moveState(source, source.getRelative(event.getDirection().getOppositeFace()));
+        List<Block> movedBlocks = event.getBlocks();
+        if(movedBlocks.size() > 0)
+        {
+            DBTransaction update = mod.getModel().groupUpdate();
+            for(int count = movedBlocks.size()-1; count >= 0; count--){
+        	Block sblock = movedBlocks.get(count);
+        	Block dest = sblock.getRelative(event.getDirection());
+        	if (mod.isDebug())
+        	    mod.getLog().debug("PistionRetract moves "+sblock.getType()+"-Block from "+sblock.getLocation()+" to "+dest.getLocation());
+        	
+        	update.moveState(sblock, dest);
+            }
+            update.finish();
         }
     }
 }

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/BlockState.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/BlockState.java
@@ -1,6 +1,7 @@
 package de.jaschastarke.minecraft.limitedcreative.blockstate;
 
 import java.util.Date;
+import java.util.UUID;
 
 import javax.persistence.Column;
 //import javax.persistence.EmbeddedId;
@@ -37,7 +38,7 @@ public class BlockState {
     private GameMode gameMode;
     
     @Column(name = "player")
-    private String playerName;
+    private UUID uuid;
     
     @NotNull
     @Column(name = "cdate")
@@ -51,7 +52,7 @@ public class BlockState {
     public BlockState(BlockState copy) {
         this.location = copy.location;
         this.gameMode = copy.gameMode;
-        this.playerName = copy.playerName;
+        this.uuid = copy.uuid;
         this.date = copy.date;
         this.source = copy.source;
     }
@@ -72,24 +73,29 @@ public class BlockState {
         this.gameMode = gm;
     }
 
-    public String getPlayerName() {
-        return playerName;
+    public UUID getPlayerUUID() {
+        return uuid;
     }
     
+    public String getPlayerName() {
+        return Bukkit.getOfflinePlayer(uuid).getName();
+    }
+    
+    //TODO Rename
     public void setPlayerName(String s) {
-        playerName = s;
+        uuid = UUID.fromString(s);
     }
     
     public OfflinePlayer getPlayer() {
-        OfflinePlayer p = Bukkit.getPlayerExact(playerName);
+        OfflinePlayer p = Bukkit.getPlayer(uuid);
         if (p == null)
-            p = Bukkit.getOfflinePlayer(playerName);
+            p = Bukkit.getOfflinePlayer(uuid);
         return p;
     }
 
     public void setPlayer(OfflinePlayer player) {
         setSource(Source.PLAYER);
-        this.playerName = player.getName();
+        this.uuid = player.getUniqueId();
         if (player instanceof Player) {
             setGameMode(((Player) player).getGameMode());
         }
@@ -119,6 +125,7 @@ public class BlockState {
 
     @Override
     public String toString() {
+	String playerName = Bukkit.getOfflinePlayer(uuid).getName();
         //return blockLocation.toString() + " by " +
         return location.toString() + " by " +
             (source == Source.PLAYER ? playerName : (source.toString() + (playerName != null ? "(" + playerName + ")" : ""))) +

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/BlockStateCommand.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/BlockStateCommand.java
@@ -7,8 +7,6 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.scheduler.BukkitRunnable;
-
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.selections.Selection;
 
@@ -105,7 +103,7 @@ public class BlockStateCommand extends BukkitCommand implements IHelpDescribed {
         if (mod.getConfig().getLogSurvival()) {
             context.responseFormatted(ChatFormattings.INFO, L("command.blockstate.nothing_to_cleanup"));
         } else {
-            mod.getPlugin().getServer().getScheduler().runTaskAsynchronously(mod.getPlugin(), new BukkitRunnable() {
+            mod.getPlugin().getServer().getScheduler().runTaskAsynchronously(mod.getPlugin(), new Runnable() {
                 @Override
                 public void run() {
                     int countDeleted = mod.getModel().cleanUp(DBModel.Cleanup.SURVIVAL);
@@ -168,7 +166,7 @@ public class BlockStateCommand extends BukkitCommand implements IHelpDescribed {
         final Location min = selection.getMinimumPoint();
         final Location max = selection.getMaximumPoint();
         
-        mod.getPlugin().getServer().getScheduler().runTaskAsynchronously(mod.getPlugin(), new BukkitRunnable() {
+        mod.getPlugin().getServer().getScheduler().runTaskAsynchronously(mod.getPlugin(), new Runnable() {
             @Override
             public void run() {
                 if (mod.isDebug())

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/DBQueries.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/DBQueries.java
@@ -138,7 +138,7 @@ public class DBQueries {
             update.setString(1, s.getGameMode().name());
         else
             update.setInt(1, s.getGameMode().getValue());
-        update.setString(2, s.getPlayerName());
+        update.setString(2, s.getPlayerUUID().toString());
         update.setTimestamp(3, new java.sql.Timestamp(s.getDate().getTime()));
         if (db.getType() == Type.MySQL)
             update.setString(4, s.getSource().name());
@@ -207,7 +207,7 @@ public class DBQueries {
             insert.setString(5, s.getGameMode().name());
         else
             insert.setInt(5, s.getGameMode().getValue());
-        insert.setString(6, s.getPlayerName());
+        insert.setString(6, s.getPlayerUUID().toString());
         insert.setTimestamp(7, new java.sql.Timestamp(s.getDate().getTime()));
         if (db.getType() == Type.MySQL)
             insert.setString(8, s.getSource().name());

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/HangingStandingListener.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/HangingStandingListener.java
@@ -11,7 +11,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/PlayerListener.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/PlayerListener.java
@@ -29,7 +29,7 @@ public class PlayerListener implements Listener {
     public void onInteract(PlayerInteractEvent event) {
         if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
             Block b = event.getClickedBlock();
-            if (b != null && event.getPlayer().getItemInHand().getType().equals(mod.getConfig().getTool()) && mod.getPlugin().getPermManager().hasPermission(event.getPlayer(), BlockStatePermissions.TOOL)) {
+            if (b != null && event.getPlayer().getInventory().getItemInMainHand().getType().equals(mod.getConfig().getTool()) && mod.getPlugin().getPermManager().hasPermission(event.getPlayer(), BlockStatePermissions.TOOL)) {
                 if (mod.getConfig().getIgnoredWorlds().contains(event.getClickedBlock().getWorld().getName())) {
                     event.getPlayer().sendMessage(mod.getPlugin().getLocale().trans("command.blockstate.world_ignored", event.getClickedBlock().getWorld().getName()));
                 } else {
@@ -41,7 +41,7 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void onInteractEntity(PlayerInteractEntityEvent event) {
         Entity e = event.getRightClicked();
-        if (e != null && e instanceof ItemFrame && event.getPlayer().getItemInHand().getType().equals(mod.getConfig().getTool()) && mod.getPlugin().getPermManager().hasPermission(event.getPlayer(), BlockStatePermissions.TOOL)) {
+        if (e != null && e instanceof ItemFrame && event.getPlayer().getInventory().getItemInMainHand().getType().equals(mod.getConfig().getTool()) && mod.getPlugin().getPermManager().hasPermission(event.getPlayer(), BlockStatePermissions.TOOL)) {
             if (mod.getConfig().getIgnoredWorlds().contains(e.getWorld().getName())) {
                 event.getPlayer().sendMessage(mod.getPlugin().getLocale().trans("command.blockstate.world_ignored", e.getWorld().getName()));
             } else {

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/worldedit/EditSessionExtent.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/blockstate/worldedit/EditSessionExtent.java
@@ -46,7 +46,7 @@ public class EditSessionExtent extends AbstractLoggingExtent {
                 s.setLocation(loc);
             }
             s.setGameMode(null);
-            s.setPlayerName(player.getName());
+            s.setPlayerName(player.getUniqueId().toString());
             s.setDate(new Date());
             s.setSource(Source.EDIT);
             if (mod.isDebug())

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/inventories/store/Fallback.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/inventories/store/Fallback.java
@@ -47,7 +47,7 @@ public class Fallback {
         @Override
         public void store(ConfigurationSection section) {
             for (int i = 0; i < inv.getSize(); i++) {
-                if (inv.getItem(i) != null && inv.getItem(i).getTypeId() != 0)
+                if (inv.getItem(i) != null && !inv.getItem(i).getType().equals(Material.AIR))
                     sectionSetItem(section, String.valueOf(i), inv.getItem(i));
             }
         }
@@ -97,7 +97,7 @@ public class Fallback {
         public static Map<Integer, ItemStack> storeInventory(PlayerInventory inv) {
             Map<Integer, ItemStack> map = new HashMap<Integer, ItemStack>();
             for (int i = 0; i < inv.getSize(); i++) {
-                if (inv.getItem(i) != null && inv.getItem(i).getTypeId() != 0) {
+                if (inv.getItem(i) != null && !inv.getItem(i).getType().equals(Material.AIR)) {
                     map.put(i, inv.getItem(i));
                 }
             }
@@ -133,13 +133,13 @@ public class Fallback {
         
         @Override
         public void store(ConfigurationSection section) {
-            if (inv.getHelmet() != null && inv.getHelmet().getTypeId() != 0)
+            if (inv.getHelmet() != null && !inv.getHelmet().getType().equals(Material.AIR))
                 Items.sectionSetItem(section, "helmet", inv.getHelmet());
-            if (inv.getChestplate() != null && inv.getChestplate().getTypeId() != 0)
+            if (inv.getChestplate() != null && !inv.getChestplate().getType().equals(Material.AIR))
                 Items.sectionSetItem(section, "chestplate", inv.getChestplate());
-            if (inv.getLeggings() != null && inv.getLeggings().getTypeId() != 0)
+            if (inv.getLeggings() != null && !inv.getLeggings().getType().equals(Material.AIR))
                 Items.sectionSetItem(section, "leggins", inv.getLeggings());
-            if (inv.getBoots() != null && inv.getBoots().getTypeId() != 0)
+            if (inv.getBoots() != null && !inv.getBoots().getType().equals(Material.AIR))
                 Items.sectionSetItem(section, "boots", inv.getBoots());
         }
 

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/inventories/store/InvYamlStorage.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/inventories/store/InvYamlStorage.java
@@ -71,9 +71,9 @@ public class InvYamlStorage extends InvConfStorage {
     
     protected File getFile(Inventory pinv, Target target) {
         if (target != default_target) {
-            return new File(dir, pinv.getPlayer().getName() + "_" + target.toString().toLowerCase() + SUFFIX);
+            return new File(dir, pinv.getPlayer().getUniqueId() + "_" + target.toString().toLowerCase() + SUFFIX);
         } else {
-            return new File(dir, pinv.getPlayer().getName() + SUFFIX);
+            return new File(dir, pinv.getPlayer().getUniqueId() + SUFFIX);
         }
     }
 }

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/BlackList.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/BlackList.java
@@ -55,7 +55,7 @@ public class BlackList extends ArrayList<BlackList.Blacklisted> implements Confi
         }
         public boolean matches(Block block) {
             if (hasData) {
-                return md.equals(new MaterialData(block.getType(), block.getData()));
+                return md.equals(block.getState().getData());
             } else {
                 return block.getType().equals(md.getItemType());
             }

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/BlackListEntity.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/BlackListEntity.java
@@ -52,7 +52,7 @@ public class BlackListEntity extends ArrayList<BlackListEntity.Blacklisted> impl
                 type = null;
             }
             if (type == null)
-                type = EntityType.fromName(rep);
+                type = EntityType.valueOf(rep);
             try {
                 if (type == null)
                     type = EntityType.valueOf(rep);

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/NoLimitPermissions.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/NoLimitPermissions.java
@@ -118,16 +118,16 @@ public class NoLimitPermissions extends SimplePermissionContainerNode {
         return new InventoryPermission(CHEST, invtype);
     }
     public static IDynamicPermission INTERACT(Block block) {
-        return new MaterialPermission(BASE_INTERACT, new MaterialData(block.getType(), block.getData()));
+        return new MaterialPermission(BASE_INTERACT, block.getState().getData());
     }
     public static IDynamicPermission USE(Block block) {
-        return new MaterialPermission(BASE_USE, new MaterialData(block.getType(), block.getData()));
+        return new MaterialPermission(BASE_USE, block.getState().getData());
     }
     public static IDynamicPermission USE(MaterialData m) {
         return new MaterialPermission(BASE_USE, m);
     }
     public static IDynamicPermission BREAK(Block block) {
-        return new MaterialPermission(BASE_BREAK, new MaterialData(block.getType(), block.getData()));
+        return new MaterialPermission(BASE_BREAK, block.getState().getData());
     }
 
     

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/PlayerListener.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/limits/PlayerListener.java
@@ -195,8 +195,8 @@ public class PlayerListener implements Listener {
     @EventHandler
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
         if (!event.isCancelled() && event.getPlayer().getGameMode() == GameMode.CREATIVE) {
-            if (mod.getConfig().getBlockUse().isListed(event.getPlayer().getItemInHand())) {
-                if (!checkPermission(event, NoLimitPermissions.USE(event.getPlayer().getItemInHand().getData()))) {
+            if (mod.getConfig().getBlockUse().isListed(event.getPlayer().getInventory().getItemInMainHand())) {
+                if (!checkPermission(event, NoLimitPermissions.USE(event.getPlayer().getInventory().getItemInMainHand().getData()))) {
                     event.setCancelled(true);
                     event.getPlayer().sendMessage(mod.getPlugin().getLocale().trans("blocked.use"));
                     return;

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/RegionsCommand.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/RegionsCommand.java
@@ -138,7 +138,7 @@ public class RegionsCommand extends BukkitCommand implements IHelpDescribed {
             if (idx > -1 && context.getArgument(idx) != null)
                 w = Bukkit.getWorld(context.getArgument(idx));
             if (w != null) {
-                RegionManager mgr = getWorldGuard().getGlobalRegionManager().get(w);
+                RegionManager mgr = getWorldGuard().getRegionManager(w);
                 if (mgr != null) {
                     List<String> hints = new ArrayList<String>();
                     for (String rId : mgr.getRegions().keySet()) {
@@ -174,7 +174,7 @@ public class RegionsCommand extends BukkitCommand implements IHelpDescribed {
         if (w == null)
             throw new CommandException(L("command.worldguard.world_not_found"));
         
-        RegionManager mgr = getWorldGuard().getGlobalRegionManager().get(w);
+        RegionManager mgr = getWorldGuard().getRegionManager(w);
         ProtectedRegion region = mgr.getRegion(params.getArgument(0));
         if (region == null && params.getArgument(0).equalsIgnoreCase("__global__")) {
             region = new GlobalProtectedRegion(params.getArgument(0));
@@ -238,16 +238,16 @@ public class RegionsCommand extends BukkitCommand implements IHelpDescribed {
         
         ProtectedRegion region = null;
         if (params.getArgumentCount() == 0 && context.isPlayer()) {
-            RegionManager mgr = getWorldGuard().getGlobalRegionManager().get(context.getPlayer().getWorld());
+            RegionManager mgr = getWorldGuard().getRegionManager(context.getPlayer().getWorld());
             ApplicableRegionSet set = mgr.getApplicableRegions(context.getPlayer().getLocation());
             if (set.size() > 0) {
                 region = set.iterator().next();
             } else {
-                region = getWorldGuard().getGlobalRegionManager().get(w).getRegion(GLOBAL_REGION);
+                region = getWorldGuard().getRegionManager(w).getRegion(GLOBAL_REGION);
             }
         } else {
             int rpc = params.getArgumentCount() > 1 ? 1 : 0;
-            RegionManager mgr = getWorldGuard().getGlobalRegionManager().get(w);
+            RegionManager mgr = getWorldGuard().getRegionManager(w);
             region = mgr.getRegion(params.getArgument(rpc));
             if (region == null && params.getArgument(rpc).equalsIgnoreCase(GLOBAL_REGION)) {
                 region = new GlobalProtectedRegion(params.getArgument(rpc));

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/worldguard/ApplicableRegions.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/worldguard/ApplicableRegions.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.Player;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.StateFlag.State;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 public class ApplicableRegions {
@@ -36,28 +37,28 @@ public class ApplicableRegions {
 
     public boolean allows(StateFlag flag) {
         extendRegionFlags();
-        boolean r = regions.allows(flag);
+        boolean r = regions.queryState(null, flag).equals(State.ALLOW);
         contractRegionFlags();
         return r;
     }
     
     public boolean allows(StateFlag flag, Player player) {
         extendRegionFlags();
-        boolean r = regions.allows(flag, mgr.getWorldGuard().wrapPlayer(player));
+        boolean r = regions.queryState(mgr.getWorldGuard().wrapPlayer(player), flag).equals(State.ALLOW);
         contractRegionFlags();
         return r;
     }
     
     public <T extends Flag<V>, V> V getFlag(T flag) {
         extendRegionFlags();
-        V r = regions.getFlag(flag);
+        V r = regions.queryValue(null, flag);
         contractRegionFlags();
         return r;
     }
     
     public <T extends Flag<V>, V> V getFlag(T flag, Player player) {
         extendRegionFlags();
-        V r = regions.getFlag(flag, mgr.getWorldGuard().wrapPlayer(player));
+        V r = regions.queryValue(mgr.getWorldGuard().wrapPlayer(player), flag);
         contractRegionFlags();
         return r;
     }

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/worldguard/CustomRegionManager.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/worldguard/CustomRegionManager.java
@@ -34,7 +34,6 @@ import org.bukkit.entity.Player;
 
 import com.sk89q.worldguard.bukkit.BukkitUtil;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
-import com.sk89q.worldguard.protection.GlobalRegionManager;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
@@ -160,10 +159,7 @@ public class CustomRegionManager {
     private WorldGuardPlugin getWorldGuard() {
         return ((WorldGuardPlugin) mod.getPlugin().getServer().getPluginManager().getPlugin(WorldGuardIntegration.PLUGIN_NAME));
     }
-    
-    public GlobalRegionManager getWGGlobalManager() {
-        return getWorldGuard().getGlobalRegionManager();
-    }
+
     public RegionManager getWGManager(World world) {
         return getWorldGuard().getRegionManager(world);
     }

--- a/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/worldguard/events/PlayerUpdateAreaEvent.java
+++ b/src/main/java/de/jaschastarke/minecraft/limitedcreative/regions/worldguard/events/PlayerUpdateAreaEvent.java
@@ -17,7 +17,6 @@
  */
 package de.jaschastarke.minecraft.limitedcreative.regions.worldguard.events;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
@@ -25,11 +24,11 @@ import de.jaschastarke.minecraft.limitedcreative.regions.worldguard.ApplicableRe
 import de.jaschastarke.minecraft.limitedcreative.regions.worldguard.CustomRegionManager;
 
 public class PlayerUpdateAreaEvent extends PlayerAreaEvent {
-    private String player;
+    private Player player;
     private String hash;
     protected CustomRegionManager mgr;
     
-    public PlayerUpdateAreaEvent(CustomRegionManager mgr, String player, String hash) {
+    public PlayerUpdateAreaEvent(CustomRegionManager mgr, Player player, String hash) {
         this.mgr = mgr;
         this.player = player;
         this.hash = hash;
@@ -46,7 +45,7 @@ public class PlayerUpdateAreaEvent extends PlayerAreaEvent {
 
     @Override
     public Player getPlayer() {
-        return Bukkit.getServer().getPlayerExact(player);
+        return player;
     }
 
     private static final HandlerList handlers = new HandlerList();


### PR DESCRIPTION
I updated the methods for piston movement within the creative block logging to make use of the new 1.9 API for retrieving the blocks that will be moved by a piston push. This change fixes the issues with properly logging movements involving slime blocks and a vulnerability with non-solid blocks.

Made the appropriate changes from the comments of Pull Request #1.

Note: Requires plib's Bukkit dependency to be upgraded from 1.9 to 1.9.4-R0.1 as 1.9-SNAPSHOT no longer exists.

Update: The last commit changes the way player inventories are stored to use UUID instead of player name in the file name to avoid possible inventory loss upon name change. Block states for creative logging also now store the UUID instead.
